### PR TITLE
Add some more arrows

### DIFF
--- a/arr-test.el
+++ b/arr-test.el
@@ -19,6 +19,44 @@
                   (arr->* (/ 2)))
              2)))
 
+(ert-deftest arr-?>test ()
+  (should (null (arr-?> 3
+                        (+ 5)
+                        (member '(2 5 9))
+                        cl-first
+                        (* 9))))
+  (should (= (arr-?> 3
+                     (+ 5)
+                     (member '(2 5 8 9))
+                     cl-first
+                     (* 9))
+             72))
+  (should (= (arr-?> 3
+                     (+ 5)
+                     (member '(2 5 8 9))
+                     cl-second
+                     (* 9))
+             81))
+  (should (null (arr-?> 3
+                        (+ 5)
+                        (member '(2 5 8 9))
+                        cl-third
+                        (* 9))))
+  (should (null (arr-?> '(:a 1)
+                        (cl-getf :b)
+                        1+))))
+
+(ert-deftest arr-?>>test ()
+  (should (= (arr-?>> '((:a . 3) (:b . 5))
+                      (assoc :a)
+                      cdr
+                      1+)
+             4))
+  (should (null (arr-?>> '((:a . 3) (:b . 5))
+                         (assoc :c)
+                         cdr
+                         1+))))
+
 (ert-deftest arr-<>test ()
   (should (equal (arr-<> 10
                          (list 9 <> 11)

--- a/arr-test.el
+++ b/arr-test.el
@@ -13,6 +13,12 @@
 (ert-deftest arr->>test ()
   (should (= (arr->> 10 (/ 5)) 0)))
 
+(ert-deftest arr->*test ()
+  (should (= (arr->> 3
+                  (/ 12)
+                  (arr->* (/ 2)))
+             2)))
+
 (ert-deftest arr-<>test ()
   (should (equal (arr-<> 10
                          (list 9 <> 11)

--- a/arr.el
+++ b/arr.el
@@ -99,6 +99,19 @@ Also known as diamond spear."
              forms
              :initial-value initial-form))
 
+;;;###autoload
+(defmacro arr->* (&rest forms)
+  "Like arr->, but takes its initial form as the last argument, rather than the
+first.  This is intended for nesting insert-arg-first forms within an arr->>.
+
+Example:
+
+    (arr->> 3
+         (/ 12)
+         (arr->* (/ 2)))
+    => 2"
+  `(arr-> ,@(append (last forms) (butlast forms))))
+
 ;;; fn varients
 
 ;;;###autoload


### PR DESCRIPTION
I found https://gitlab.com/Harleqin/arrows, which is a fork of the lib you ported with a few extra functions thrown in. I grabbed two, and may also port `-cond->` and `-cond->>`, which thread values through lists of `(condition eval-me-if-condition-is-truthy)` forms (values are inserted into applicable `eval-me-...` expressions per the number of `>`s).

- `arr->*` takes its initial form last, which lets you nest insert-arg-first forms inside an `arr->>`
- `arr-?>` and `arr-?>>` short-circuit to `nil` if their initial value or any of their forms evaluate to `nil`. The library named them `-some->` &c, but I like `-?>` better on a few levels.